### PR TITLE
See what happens when publishing a non-SNAPSHOT version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.mycompany.app</groupId> <!-- package name -->
   <artifactId>my-app</artifactId>
-  <version>1.0-alpha</version> <!-- package version -->  
+  <version>1.0-alpha</version> <!-- package version -->  <!-- bump -->
   <name>my-app</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.mycompany.app</groupId> <!-- package name -->
   <artifactId>my-app</artifactId>
-  <version>1.0-SNAPSHOT</version> <!-- package version -->  
+  <version>1.0-alpha</version> <!-- package version -->  
   <name>my-app</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>


### PR DESCRIPTION
When a Maven package version already exists, `mvn deploy` fails with `422 Unprocessable Entity`.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project my-app: Failed to deploy artifacts: Could not transfer artifact com.mycompany.app:my-app:jar:1.0-alpha from/to maven-example (***maven.pkg.github.com/actions-packages-examples/maven-example): Transfer failed for https://maven.pkg.github.com/actions-packages-examples/maven-example/com/mycompany/app/my-app/1.0-alpha/my-app-1.0-alpha.jar 422 Unprocessable Entity -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
##[error]Process completed with exit code 1.
```

https://github.com/actions-packages-examples/maven-example/runs/567357272#step:5:430